### PR TITLE
Guilds are now tracked in dynamo

### DIFF
--- a/admin/adminutils.py
+++ b/admin/adminutils.py
@@ -1,6 +1,19 @@
 import sys
 import json
 import boto3
+import os
+from tehbot.settings import get_guildid, list_guilds
+from typing import Optional, Iterable, Tuple
+
+def get_env_guildid(env:str, guild_name:str) -> str:
+    settings_table:str = get_cft_resource(env, "DynamoTables", "SettingsTable")
+    os.environ["DYNAMOTABLE_SETTINGS"] = settings_table
+    return get_guildid(guild_name)
+
+def get_env_guilds(env:str) -> Iterable[Tuple[str, str]]:
+    settings_table:str = get_cft_resource(env, "DynamoTables", "SettingsTable")
+    os.environ["DYNAMOTABLE_SETTINGS"] = settings_table
+    return list_guilds()
 
 def get_cft_resource(env, stack, resource):
     if env == "prod":

--- a/admin/deploy.py
+++ b/admin/deploy.py
@@ -325,16 +325,16 @@ def stack_lambdas(ctx):
         stackname = f"tehBot-{ctx['args'].env}Lambdas"
         upsert_stack(ctx, stackname, "../cft/lambdas.yml", params)
 
-        for guildname in ctx["local"]["guilds"]:
-            guildid = ctx["local"]["guilds"][guildname]
-            stackname = f"tehBot-{ctx['args'].env}LambdaSchedules{guildname}"
-            upsert_stack(ctx, stackname, "../cft/lambda_schedules.yml", {"GuildName": guildname, "GuildId": guildid})
+        # for guildname in ctx["local"]["guilds"]:
+        #     guildid = ctx["local"]["guilds"][guildname]
+        #     stackname = f"tehBot-{ctx['args'].env}LambdaSchedules{guildname}"
+        #     upsert_stack(ctx, stackname, "../cft/lambda_schedules.yml", {"GuildName": guildname, "GuildId": guildid})
         
     elif ctx["args"].action == "delete":
-        for guildname in ctx["local"]["guilds"]:
-            guildid = ctx["local"]["guilds"][guildname]
-            stackname = f"tehBot-{ctx['args'].env}LambdaSchedules{guildname}"
-            delete_stack(ctx, stackname)
+        # for guildname in ctx["local"]["guilds"]:
+        #     guildid = ctx["local"]["guilds"][guildname]
+        #     stackname = f"tehBot-{ctx['args'].env}LambdaSchedules{guildname}"
+        #     delete_stack(ctx, stackname)
         stackname = f"tehBot-{ctx['args'].env}Lambdas"
         delete_stack(ctx, stackname)
 

--- a/admin/import_quotes.py
+++ b/admin/import_quotes.py
@@ -12,7 +12,7 @@ if __name__ == "__main__":
     from tehbot.quotes import Quote
 
     guild_name = sys.argv[2]
-    guild_id = local["guilds"][guild_name]
+    guild_id = adminutils.get_env_guildid(env, guild_name)
     
     quotes = []
     quotes.extend(Quote.find_all(guild_id))

--- a/admin/manage_admin.py
+++ b/admin/manage_admin.py
@@ -8,7 +8,7 @@ if __name__ == "__main__":
     local = adminutils.get_local(env)
 
     guild_name = sys.argv[2]
-    guild_id = local["guilds"][guild_name]
+    guild_id = adminutils.get_env_guildid(env, guild_name)
 
     roletype = sys.argv[3]
 

--- a/admin/manage_guilds.py
+++ b/admin/manage_guilds.py
@@ -1,0 +1,21 @@
+import os
+from tehbot.aws import from_dynamo_item
+import adminutils
+from typing import Optional
+
+if __name__ == "__main__":
+    import sys
+    env:str = sys.argv[1]
+    operation:str = sys.argv[2]
+    settings_table:str = adminutils.get_cft_resource(env, "DynamoTables", "SettingsTable")
+    os.environ["DYNAMOTABLE_SETTINGS"] = settings_table
+    from tehbot.settings import get_settings, upsert_settings
+    if operation == "add":
+        guild_name:str = sys.argv[3]
+        guild_id:str = sys.argv[4]
+        try:
+            status: Optional[dict] = get_settings(guild_id, "guild_status")
+        except IndexError:
+            status = {}
+        status["GuildName"] = guild_name
+        upsert_settings(guild_id, "guild_status", **status)

--- a/admin/manage_maintenance.py
+++ b/admin/manage_maintenance.py
@@ -20,7 +20,7 @@ if __name__ == "__main__":
 
     sqs = boto3.client("sqs")
     
-    for guildname in local["guilds"]:
-        guildid = local["guilds"][guildname]
+    for guildname, guildid in adminutils.get_env_guilds(env):
+        # guildid = local["guilds"][guildname]
         message["guildid"] = guildid
         sqs.send_message(QueueUrl=queue_url, MessageBody=json.dumps(message))

--- a/admin/manage_webhook.py
+++ b/admin/manage_webhook.py
@@ -5,6 +5,7 @@ import adminutils
 
 if __name__ == "__main__":
     import sys
+    env = sys.argv[1]
     guild_name = sys.argv[2]
     webhook_name = sys.argv[3]
 
@@ -16,7 +17,7 @@ if __name__ == "__main__":
         body = json.load(f)
     
     app_id = secrets["application_id"]
-    guild_id = local["guilds"][guild_name]
+    guild_id = adminutils.get_env_guildid(env, guild_name)
     
     headers = {
         "Authorization": f"Bot {secrets['discord_bot_token']}"

--- a/cft/apicomponents.yml
+++ b/cft/apicomponents.yml
@@ -12,29 +12,6 @@ Parameters:
     Type: String
 
 Resources:
-  CronLambdaTokenCleanupSchedule:
-    Type: AWS::Events::Rule
-    Properties:
-      Description: !Sub "ScheduleRule for token_cleanup (${EnvPrefix})"
-      ScheduleExpression: "rate(1 hour)"
-      State: "ENABLED"
-      Targets: 
-        - Arn: !ImportValue
-            'Fn::Sub': "tehBot-${EnvPrefix}CronLambdaArn"
-          Id: "token_cleanup"
-          Input: |
-            {
-              "op": "token_cleanup"
-            }
-  CronLambdaPerms:
-    Type: AWS::Lambda::Permission
-    Properties:
-      FunctionName: !ImportValue
-        'Fn::Sub': "tehBot-${EnvPrefix}CronLambdaArn"
-      Action: "lambda:InvokeFunction"
-      Principal: "events.amazonaws.com"
-      SourceArn: !GetAtt CronLambdaTokenCleanupSchedule.Arn
-
   AuthTokenPostLambdaStack:
     Type: AWS::CloudFormation::Stack
     Properties:

--- a/cft/apigateway.yml
+++ b/cft/apigateway.yml
@@ -77,16 +77,6 @@ Resources:
       AliasTarget:
         DNSName: !GetAtt ApiDomainName.RegionalDomainName
         HostedZoneId: !GetAtt ApiDomainName.RegionalHostedZoneId
-  
-
-  DiscordInteractionsLambdaPermission:
-    Type: AWS::Lambda::Permission
-    Properties:
-      Action: "lambda:InvokeFunction"
-      FunctionName: !ImportValue
-          'Fn::Sub': "tehBot-${EnvPrefix}WebhookLambdaArn"
-      Principal: apigateway.amazonaws.com
-
 
   ApiGatewayLoggingRole:
     Condition: Prod

--- a/cft/lambdas.yml
+++ b/cft/lambdas.yml
@@ -42,6 +42,14 @@ Resources:
             'Fn::Sub': "tehBot-${EnvPrefix}LambdaSecretsArn"
           DYNAMOTABLE_SETTINGS: !ImportValue
             'Fn::Sub': "tehBot-${EnvPrefix}SettingsTable"
+
+  WebhookLambdaPermission:
+    Type: AWS::Lambda::Permission
+    Properties:
+      Action: "lambda:InvokeFunction"
+      FunctionName: !Ref WebhookLambda
+      Principal: apigateway.amazonaws.com
+      SourceAccount: !Sub "${AWS::AccountId}"
   
   CronLambda:
     Type: AWS::Lambda::Function
@@ -53,6 +61,7 @@ Resources:
       Handler: lambda_function.lambda_handler
       Role: !ImportValue
         'Fn::Sub': "tehBot-${EnvPrefix}CronLambdaRoleArn"
+      FunctionName: !Sub "tehBot-${EnvPrefix}CronLambda"
       Runtime: "python3.9"
       PackageType: Zip
       Timeout: 15
@@ -70,7 +79,59 @@ Resources:
             'Fn::Sub': "tehBot-${EnvPrefix}SettingsTable"
           DYNAMOTABLE_API: !ImportValue
             'Fn::Sub': "tehBot-${EnvPrefix}ApiTable"
-  
+  CronLambdaScheduleLobby:
+    Type: AWS::Events::Rule
+    Properties:
+      Description: !Sub "ScheduleRule for (${EnvPrefix})"
+      ScheduleExpression: "rate(5 minutes)"
+      State: "ENABLED"
+      Targets: 
+        - Arn: !GetAtt [CronLambda, Arn]
+          Id: !Sub "Cron-Schedule-${EnvPrefix}"
+          Input: |
+            {
+              "op": "lobby_update"
+            }
+          # {
+          #   "op": "lobby_update",
+          #   "guildid": "${GuildId}"
+          # }
+  CronLambdaLobbyPerms:
+    Type: AWS::Lambda::Permission
+    Properties:
+      FunctionName: !GetAtt [CronLambda, Arn]
+      Action: "lambda:InvokeFunction"
+      Principal: "events.amazonaws.com"
+      SourceArn: !GetAtt CronLambdaScheduleLobby.Arn
+  CronLambdaSelfPerms:
+    Type: AWS::Lambda::Permission
+    Properties:
+      FunctionName: !GetAtt [CronLambda, Arn]
+      Action: "lambda:InvokeFunction"
+      Principal: "lambda.amazonaws.com"
+      SourceArn: !GetAtt [CronLambda, Arn]
+  CronLambdaTokenCleanupSchedule:
+    Type: AWS::Events::Rule
+    Properties:
+      Description: !Sub "ScheduleRule for token_cleanup (${EnvPrefix})"
+      ScheduleExpression: "rate(1 hour)"
+      State: "ENABLED"
+      Targets: 
+        - Arn: !GetAtt [CronLambda, Arn]
+          Id: "token_cleanup"
+          Input: |
+            {
+              "op": "token_cleanup"
+            }
+  CronLambdaTokenCleanupPerms:
+    Type: AWS::Lambda::Permission
+    Properties:
+      FunctionName: !GetAtt [CronLambda, Arn]
+      Action: "lambda:InvokeFunction"
+      Principal: "events.amazonaws.com"
+      SourceArn: !GetAtt CronLambdaTokenCleanupSchedule.Arn
+
+
   WorkerLambda:
     Type: AWS::Lambda::Function
     Properties:
@@ -81,6 +142,7 @@ Resources:
       Handler: lambda_function.lambda_handler
       Role: !ImportValue
         'Fn::Sub': "tehBot-${EnvPrefix}WorkerLambdaRoleArn"
+      FunctionName: !Sub "tehBot-${EnvPrefix}WorkerLambda"
       Runtime: "python3.9"
       PackageType: Zip
       Timeout: 90
@@ -129,6 +191,7 @@ Resources:
         ImageUri: !Ref HeavyWorkerDockerImageUri
       Role: !ImportValue
         'Fn::Sub': "tehBot-${EnvPrefix}WorkerLambdaRoleArn"
+      FunctionName: !Sub "tehBot-${EnvPrefix}HeavyWorkerLambda"
       PackageType: Image
       Timeout: 90
       MemorySize: 160

--- a/cft/roles.yml
+++ b/cft/roles.yml
@@ -323,6 +323,17 @@ Resources:
         - !Ref SteamLobbyTablePolicy
         - !Ref S3CacheBucketPolicy
         - !Ref ApiTablePolicy
+      Policies:
+        - PolicyDocument: 
+            Version: "2012-10-17"
+            Statement:
+              - Effect: "Allow"
+                Action:
+                 - "lambda:InvokeFunction"
+                Resource:
+                 - !Sub "arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:function:tehBot-${EnvPrefix}CronLambda"
+                 - !Sub "arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:function:tehBot-${EnvPrefix}CronLambda/*"
+          PolicyName: InvokeSelf
 
   WorkerLambdaRole:
     Type: AWS::IAM::Role

--- a/local.json.example
+++ b/local.json.example
@@ -6,9 +6,6 @@
         "cert_arn": "",
         "us-east-1_cert_arn": "",
         "root_discord_user_id": "",
-        "guilds": {
-            "name": "id"
-        },
         "discord_oauth_url": "",
         "tehbot_api_url": "",
         "tehbot_web_url": "",


### PR DESCRIPTION
fixes #4 and includes changes for Cron lambda to have a per-guild fanout approach to prevent possible future timeout issues.

Also moved permissions for APIGateway to invoke the WebhookLambda to the Lambdas stack in CFN. This makes redeploying lambdas easier.